### PR TITLE
fixes image size issue in members page

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -2057,6 +2057,7 @@ figure.effect-zoe {
   img {
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;
+    width: 300px;
   }
 
   .name {


### PR DESCRIPTION
sets the image width to 300px to fix overflowing images issue in members page
